### PR TITLE
スマホからタイムテーブルのモーダルを閉じるボタンが押しづらい のCSS修正

### DIFF
--- a/2025/index.css
+++ b/2025/index.css
@@ -527,13 +527,9 @@ a.session .name {
   color: #fff;
   text-align: center;
   margin: 0 0 0 auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   position: relative;
   z-index: 1;
   cursor: pointer;
-  padding-bottom: 3px; /* Flexboxの中央配置により×が若干下に移動したように見えるため、視覚的な調整 */
 }
 #session-modal-close:focus,
 #session-modal-close:hover {

--- a/2025/index.css
+++ b/2025/index.css
@@ -527,6 +527,13 @@ a.session .name {
   color: #fff;
   text-align: center;
   margin: 0 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  z-index: 1;
+  cursor: pointer;
+  padding-bottom: 3px; /* Flexboxの中央配置により×が若干下に移動したように見えるため、視覚的な調整 */
 }
 #session-modal-close:focus,
 #session-modal-close:hover {


### PR DESCRIPTION
## 概要

セッションモーダルの閉じるボタンのstyle修正
- 要素を前面に出すようにしてスマホ/PCでも閉じるボタンを押しやすくした
- (ついでに)オンマウス時の表示をポインターに変更

## 動作確認

* [x] 要素の端側でも閉じるボタンを押下して、閉じられることを確認

### スマホ版

https://github.com/user-attachments/assets/d7aaeb6b-0dd0-4bff-ac7c-a239fb3524eb

### PC版

https://github.com/user-attachments/assets/cb5a11bf-66c5-4d12-856e-f7691d0c97ca


